### PR TITLE
add force redirect option to remote response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "johnitvn/yii2-ajaxcrud",
+    "name": "jeffwalsh/yii2-ajaxcrud",
     "description": "Gii CRUD template for Single Page Ajax Administration for yii2",
     "type": "yii2-extension",
     "keywords": ["yii2","extension","ajax","crud","gii","template","database"],
@@ -12,8 +12,8 @@
         }
     ],
     "support": {
-        "issues": "https://github.com/johnitvn/yii2-ajaxcrud/issues?state=open",
-        "source": "https://github.com/johnitvn/yii2-ajaxcrud"
+        "issues": "https://github.com/jeffwalsh/yii2-ajaxcrud/issues?state=open",
+        "source": "https://github.com/jeffwalsh/yii2-ajaxcrud"
     },
     "require": {
         "yiisoft/yii2": "*",

--- a/src/assets/ModalRemote.js
+++ b/src/assets/ModalRemote.js
@@ -247,6 +247,10 @@ function ModalRemote(modalId) {
                 $(this.footer).find('[type="submit"]')[0]
             );
         }
+
+        if(response.forceRedirect !== undefined && response.forceRedirect) {
+            window.location.reload(response.forceRedirect);
+        }
     }
 
     /**


### PR DESCRIPTION
Hi there. This is a handy option for those of us who need to return a redirect, without having that redirect end up IN the modal (ie: a big "302!").